### PR TITLE
Use non-strict comparison in coverage criteria

### DIFF
--- a/addons/coverage/Coverage.gd
+++ b/addons/coverage/Coverage.gd
@@ -367,8 +367,8 @@ func coverage_passing() -> bool:
 	if _coverage_target_file < INF:
 		for script in coverage_collectors:
 			var script_percent = coverage_collectors[script].coverage_percent()
-			all_files_passing = all_files_passing && script_percent > _coverage_target_file
-	return coverage_percent() > _coverage_target_total && all_files_passing
+			all_files_passing = all_files_passing && script_percent >= _coverage_target_file
+	return coverage_percent() >= _coverage_target_total && all_files_passing
 
 # see ScriptCoverage.Verbosity for verbosity levels
 func script_coverage(verbosity := 0):


### PR DESCRIPTION
First of all, thanks for making this addon! It's the best coverage support for Godot I found so far. I hope I'm not braking any protocols with this PR.

As for the reason behind this PR:

In most cases using greather-than should work, but in a project at work we have 100% coverage (for now, at least) and we cannot enforce that threshold because 100 is never greater than 100.

